### PR TITLE
fix: empty vast data structure is created when no ad tag

### DIFF
--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -488,10 +488,10 @@ class CastPlayer extends BaseRemotePlayer {
       audioLanguage: snapshot.audioLanguage,
       textLanguage: snapshot.textLanguage
     };
-    if (snapshot.advertising) {
+    if (snapshot.advertising && snapshot.advertising.adTagUrl) {
       this._adsController = new CastAdsController();
-      const advertising = this._config.advertising;
-      if (!advertising || !advertising.vast) {
+      const castAdvertising = this._config.advertising;
+      if (!castAdvertising || !castAdvertising.vast) {
         loadOptions.media.vmapAdsRequest = this._getAdsRequest(snapshot.advertising);
       } else {
         const breakClipId = Utils.Generator.uniqueId(5);


### PR DESCRIPTION
### Description of the Changes

Don't create vast data structure in case of ad tag is empty.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
