### PR TITLE
feat(FEC-8682): end screen

### DIFF
--- a/src/cast-ui.js
+++ b/src/cast-ui.js
@@ -32,7 +32,6 @@ class CastUI extends RemotePlayerUI {
           <Components.PlaybackControls player={props.player} />
         </div>
         <Components.PrePlaybackPlayOverlay player={props.player} />
-        <Components.CastAfterPlay player={props.player} />
       </div>
     );
   }
@@ -62,7 +61,6 @@ class CastUI extends RemotePlayerUI {
           <Components.PlaybackControls player={props.player} />
         </div>
         <Components.PrePlaybackPlayOverlay player={props.player} />
-        <Components.CastAfterPlay player={props.player} />
       </div>
     );
   }


### PR DESCRIPTION
### Description of the Changes

remove `CastAfterPlay` component because the chromecast button is exposed as part of the bottom bar also on ended. 
depended on https://github.com/kaltura/playkit-js-ui/pull/306

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
