### PR TITLE
fix(FEC-8616): fix(FEC-8616): When Seeking a video, the scrubber is jumping back before the seek is applied

### DIFF
--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -652,6 +652,8 @@ class CastPlayer extends BaseRemotePlayer {
     this._eventManager.listen(this._engine, EventType.MUTE_CHANGE, e => this.dispatchEvent(e));
     this._eventManager.listen(this._engine, EventType.DURATION_CHANGE, e => this.dispatchEvent(e));
     this._eventManager.listen(this._engine, EventType.ENDED, e => this._onEnded(e));
+    this._eventManager.listen(this._engine, EventType.SEEKING, e => this.dispatchEvent(e));
+    this._eventManager.listen(this._engine, EventType.SEEKED, e => this.dispatchEvent(e));
     this._eventManager.listen(this._tracksManager, EventType.TRACKS_CHANGED, e => this.dispatchEvent(e));
     this._eventManager.listen(this._tracksManager, EventType.TEXT_TRACK_CHANGED, e => this.dispatchEvent(e));
     this._eventManager.listen(this._tracksManager, EventType.VIDEO_TRACK_CHANGED, e => this.dispatchEvent(e));


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
