### PR TITLE
fix(FEC-8616): When Seeking a video, the scrubber is jumping back before the seek is applied

### DIFF
--- a/src/cast-playback-engine.js
+++ b/src/cast-playback-engine.js
@@ -198,7 +198,7 @@ class CastPlaybackEngine extends FakeEventTarget {
   _maybeDispatchTimeUpdate(): void {
     if (!this._seeking) {
       this.dispatchEvent(new FakeEvent(EventType.TIME_UPDATE));
-    } else if (this._seekTargetTime && this._currentTime >= this._seekTargetTime) {
+    } else if (this._seekTargetTime && this._currentTime === this._seekTargetTime) {
       this._seeking = false;
       this._seekTargetTime = null;
       this.dispatchEvent(new FakeEvent(EventType.SEEKED));

--- a/src/cast-playback-engine.js
+++ b/src/cast-playback-engine.js
@@ -14,6 +14,7 @@ class CastPlaybackEngine extends FakeEventTarget {
   _currentTime: number = 0;
   _duration: number = 0;
   _seeking: boolean = false;
+  _seekForward: boolean;
   _seekTargetTime: ?number;
   _liveCurrentTimeIntervalId: number;
   _onCurrentTimeChanged: Function;
@@ -75,6 +76,7 @@ class CastPlaybackEngine extends FakeEventTarget {
       this._seeking = true;
       this.dispatchEvent(new FakeEvent(EventType.SEEKING));
       this._remotePlayer.currentTime = this._seekTargetTime = value;
+      this._seekForward = value > this.currentTime;
       this._remotePlayerController.seek();
     }
   }
@@ -198,7 +200,10 @@ class CastPlaybackEngine extends FakeEventTarget {
   _maybeDispatchTimeUpdate(): void {
     if (!this._seeking) {
       this.dispatchEvent(new FakeEvent(EventType.TIME_UPDATE));
-    } else if (this._seekTargetTime && this._currentTime === this._seekTargetTime) {
+    } else if (
+      this._seekTargetTime &&
+      ((this._seekForward && this.currentTime >= this._seekTargetTime) || (!this._seekForward && this.currentTime <= this._seekTargetTime))
+    ) {
       this._seeking = false;
       this._seekTargetTime = null;
       this.dispatchEvent(new FakeEvent(EventType.SEEKED));

--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -2,7 +2,7 @@
 import {cast as remote, core} from 'kaltura-player-js';
 import {CastStateManager} from './cast-state-manager';
 import {CastTracksManager} from './cast-tracks-manager';
-import {CastPlaybackEngine} from './cast-playack-engine';
+import {CastPlaybackEngine} from './cast-playback-engine';
 import {CastUI} from './cast-ui';
 import {CastLoader} from './cast-loader';
 import {CastAdsController} from './cast-ads-controller';


### PR DESCRIPTION
### Description of the Changes

Change the target time condition from ```>=``` to ```===```

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
