### PR TITLE
fix(FEC-8768): seeking back on ended doesn't work when casting

### DIFF
--- a/src/cast-ui.js
+++ b/src/cast-ui.js
@@ -32,6 +32,7 @@ class CastUI extends RemotePlayerUI {
           <Components.PlaybackControls player={props.player} />
         </div>
         <Components.PrePlaybackPlayOverlay player={props.player} />
+        <Components.CastAfterPlay player={props.player} />
       </div>
     );
   }
@@ -61,6 +62,7 @@ class CastUI extends RemotePlayerUI {
           <Components.PlaybackControls player={props.player} />
         </div>
         <Components.PrePlaybackPlayOverlay player={props.player} />
+        <Components.CastAfterPlay player={props.player} />
       </div>
     );
   }


### PR DESCRIPTION
This reverts commit 9d1c007

### Description of the Changes

Use `CastAfterPlay` component because from https://github.com/kaltura/playkit-js-ui/pull/342 there is no bottom bar when casting is ended 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
