### PR TITLE
fix(FEC-8879): when no cast device is available, cast button appear but only before playback

### DIFF
--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -578,10 +578,12 @@ class CastPlayer extends BaseRemotePlayer {
     options.autoJoinPolicy = this._castConfig.autoJoinPolicy || chrome.cast.AutoJoinPolicy.ORIGIN_SCOPED;
 
     this._logger.debug('Init cast API with options', options);
-    cast.framework.CastContext.getInstance().setOptions(options);
-
-    const payload = new RemoteAvailablePayload(this, true);
-    this._remoteControl.onRemoteDeviceAvailable(payload);
+    const castContext = cast.framework.CastContext.getInstance();
+    castContext.setOptions(options);
+    castContext.addEventListener(cast.framework.CastContextEventType.CAST_STATE_CHANGED, event => {
+      const payload = new RemoteAvailablePayload(this, event.castState !== cast.framework.CastState.NO_DEVICES_AVAILABLE);
+      this._remoteControl.onRemoteDeviceAvailable(payload);
+    });
   }
 
   _initializeRemotePlayer(): void {


### PR DESCRIPTION
### Description of the Changes

Listen to `CAST_STATE_CHANGED` and trigger `CAST_AVAILABLE` accordingly for UI update

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
