### PR TITLE
fix(FEC-9618): when casting, LIVE indicator is not on PC (Device which performs the casting to TV)

### DIFF
--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -789,7 +789,7 @@ class CastPlayer extends BaseRemotePlayer {
     this._tracksManager.parseTracks();
     this._handleFirstPlay();
     let startTime = this._playerConfig.playback.startTime;
-    if (this.isLive() && (startTime === -1 || startTime >= this.duration - LIVE_EDGE_THRESHOLD)) {
+    if (this.isLive() && (startTime === -1 || (typeof this.duration === 'number' && startTime >= this.duration - LIVE_EDGE_THRESHOLD))) {
       this._isOnLiveEdge = true;
     }
   }


### PR DESCRIPTION
### Description of the Changes

Implement `isOnLiveEdge()` in cast-player.
Because the DVR isn't working properly (for now) the logic is as follows:
it always `true` unless the player is paused or `playback.startTime` is less than the `duration` (includes a threshold of `10`*), as this is the only case the DVR is working 

\* can be handled by `cast.dvrThreshold` too

Solves FEC-9618

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
