### PR TITLE
fix(FEC-9157): cannot cast video on android chrome

### DIFF
--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -640,7 +640,8 @@ class CastPlayer extends BaseRemotePlayer {
     );
     const payload = new RemoteConnectedPayload(this, this._remoteSession, this._ui);
     this._remoteControl.onRemoteDeviceConnected(payload);
-    if (this._remoteSession.resuming) {
+    if (this._remoteSession.resuming && !(Env.browser.major >= 73 && Env.os.name === 'Android')) {
+      // Android Chrome 73 and up gets SESSION_RESUMED also in the initial session
       this._resumeSession();
     } else if (snapshot) {
       const loadOptions = this._getLoadOptions(snapshot);

--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -823,6 +823,11 @@ class CastPlayer extends BaseRemotePlayer {
         case cast.framework.SessionState.SESSION_STARTING:
           this._remoteControl.onRemoteDeviceConnecting();
           break;
+        case cast.framework.SessionState.SESSION_RESUMED:
+          if (Env.browser.major >= 73 && Env.os.name === 'Android') {
+            this._remoteControl.onRemoteDeviceConnecting();
+          }
+          break;
         case cast.framework.SessionState.SESSION_ENDING:
           this._remoteControl.onRemoteDeviceDisconnecting();
           break;


### PR DESCRIPTION
### Description of the Changes

**Issue:** Chrome Android >= 73 gets `SESSION_RESUMED` in the initial session insteadof `SESSION_STARTED` so incorrectly the player starts 'resuming' flow.
**Solution:** Turn off the 'resuming' flow in Chrome Android >= 73 (meaning the playback will start from beginning also in existing session)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
