### PR TITLE
fix(FEC-9148): ChromeCast is not available on ios mobile devices

### DIFF
--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -59,7 +59,7 @@ class CastPlayer extends BaseRemotePlayer {
    * @override
    */
   static isSupported(): boolean {
-    return Env.browser.name === 'Chrome';
+    return Env.browser.name === 'Chrome' && Env.os.name !== 'iOS';
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Un-support Chrome-Cast on iOS chrome as it is deprecated on chrome-iOS M-70 release. See:
* https://bugs.chromium.org/p/chromium/issues/detail?id=872050
* https://github.com/googlecast/CastVideos-chrome/issues/5

Solves FEC-9148, FEC-8735

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
