### PR TITLE
fix(FEC-10154): cast preset is missing the font family

### DIFF
--- a/src/cast-ui.js
+++ b/src/cast-ui.js
@@ -8,7 +8,7 @@ const {RemotePlayerUI} = cast;
 class CastUI extends RemotePlayerUI {
   playbackUI(props: Object): any {
     return (
-      <div className={style.playbackGuiWWrapper}>
+      <div className={style.playbackGuiWrapper}>
         <Components.KeyboardControl player={props.player} config={props.config} />
         <Components.Loading player={props.player} />
         <div className={style.playerGui} id="player-gui">
@@ -40,7 +40,7 @@ class CastUI extends RemotePlayerUI {
 
   liveUI(props: Object): any {
     return (
-      <div className={style.playbackGuiWWrapper}>
+      <div className={style.playbackGuiWrapper}>
         <Components.KeyboardControl player={props.player} config={props.config} />
         <Components.Loading player={props.player} />
         <div className={style.playerGui} id="player-gui">
@@ -70,7 +70,7 @@ class CastUI extends RemotePlayerUI {
 
   idleUI(props: Object): any {
     return (
-      <div className={style.playbackGuiWWrapper}>
+      <div className={style.playbackGuiWrapper}>
         <Components.Loading player={props.player} />
         <Components.CastOverlay player={props.player} />
       </div>


### PR DESCRIPTION
### Description of the Changes

fix typo. style class `playbackGuiWWrapper` to `playbackGuiWrapper`

Solves FEC-10154

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
