### PR TITLE
feat(FEC-9631): add support for out of band text tracks on cast sdk

### DIFF
--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -877,9 +877,8 @@ class CastPlayer extends BaseRemotePlayer {
         loadOptions.media.breaks = breaks;
       }
     }
-
-    try {
-      loadOptions.media.tracks = snapshot.mediaConfig.sources.captions.map((caption, index) => {
+    if (this._playerConfig.sources.captions && this._playerConfig.sources.captions.length)
+      loadOptions.media.tracks = this._playerConfig.sources.captions.map((caption, index) => {
         let newTrack;
         newTrack = new chrome.cast.media.Track(index + 1, chrome.cast.media.TrackType.TEXT);
         Utils.Object.mergeDeep(newTrack, {
@@ -889,9 +888,6 @@ class CastPlayer extends BaseRemotePlayer {
         });
         return newTrack;
       });
-    } catch (e) {
-      // do nothing
-    }
 
     return loadOptions;
   }

--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -877,6 +877,22 @@ class CastPlayer extends BaseRemotePlayer {
         loadOptions.media.breaks = breaks;
       }
     }
+
+    try {
+      loadOptions.media.tracks = snapshot.mediaConfig.sources.captions.map((caption, index) => {
+        let newTrack;
+        newTrack = new chrome.cast.media.Track(index + 1, chrome.cast.media.TrackType.TEXT);
+        Utils.Object.mergeDeep(newTrack, {
+          trackContentId: caption.url,
+          name: caption.label,
+          language: caption.language
+        });
+        return newTrack;
+      });
+    } catch (e) {
+      // do nothing
+    }
+
     return loadOptions;
   }
 

--- a/src/cast-tracks-manager.js
+++ b/src/cast-tracks-manager.js
@@ -272,8 +272,8 @@ class CastTracksManager extends FakeEventTarget {
 
   _markActiveTrack(track: ?Track, active: boolean): void {
     if (track) {
-      const id = track.id;
-      const origTrack = this._tracks.find(t => t.id === id);
+      const {id, language} = track;
+      const origTrack = this._tracks.find(t => t.id === id || (t.language === language && language === 'off'));
       if (origTrack) {
         origTrack.active = active;
       }
@@ -285,7 +285,6 @@ class CastTracksManager extends FakeEventTarget {
     if (textTracks && textTracks.length) {
       this._tracks.push(
         new TextTrack({
-          id: this._tracks.length + 1,
           active: true,
           index: textTracks.length,
           kind: 'subtitles',


### PR DESCRIPTION
### Description of the Changes

* Use [`media.tracks`](https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.MediaInfo#tracks) to pass the configured captions to the receiver 
* Ignore out-of-band caption if it already exists as in-band
* Fix 'Off' track id that can be duplicated

Solves FEC-9631

Related to https://github.com/kaltura/kaltura-player-js/pull/319

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
