### PR TITLE
fix(FEC-10156): several text tracks are active in same time while casting

### DIFF
--- a/src/cast-tracks-manager.js
+++ b/src/cast-tracks-manager.js
@@ -111,7 +111,9 @@ class CastTracksManager extends FakeEventTarget {
   }
 
   _startOnMediaStatusUpdateInterval(): void {
-    this._mediaStatusIntervalId = setInterval(this._onMediaStatusUpdate, INTERVAL_FREQUENCY);
+    if (!this._mediaStatusIntervalId) {
+      this._mediaStatusIntervalId = setInterval(this._onMediaStatusUpdate, INTERVAL_FREQUENCY);
+    }
   }
 
   _stopOnMediaStatusUpdateInterval(): void {


### PR DESCRIPTION
### Description of the Changes

Avoid starting the media status interval more than once
 
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
