### PR TITLE
fix(FEC-10661): Cast ui is missing

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,12 @@
   "ignore": ["node_modules/**/*"],
   "plugins": [
     "@babel/plugin-transform-flow-strip-types",
+    [
+      "@babel/plugin-proposal-decorators",
+      {
+        "legacy": true
+      }
+    ],
     "@babel/plugin-proposal-class-properties",
     [
       "@babel/plugin-transform-react-jsx",

--- a/.flowconfig
+++ b/.flowconfig
@@ -3,3 +3,4 @@
 [include]
 [libs]
 [options]
+esproposal.decorators=ignore

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.10.5",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
+    "@babel/plugin-proposal-decorators": "^7.10.5",
     "@babel/plugin-transform-flow-strip-types": "^7.10.4",
     "@babel/plugin-transform-react-jsx": "^7.10.4",
     "@babel/preset-env": "^7.10.4",
@@ -115,7 +116,5 @@
       "postbump": "yarn run build && npm run commit:dist"
     }
   },
-  "dependencies": {
-    "@babel/plugin-proposal-decorators": "^7.10.5"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "peerDependencies": {
-    "kaltura-player-js": "https://github.com/kaltura/kaltura-player-js.git#v1.0.0"
+    "kaltura-player-js": "https://github.com/kaltura/kaltura-player-js.git#v1.0.5"
   },
   "publishConfig": {
     "access": "public"
@@ -114,5 +114,8 @@
     "scripts": {
       "postbump": "yarn run build && npm run commit:dist"
     }
+  },
+  "dependencies": {
+    "@babel/plugin-proposal-decorators": "^7.10.5"
   }
 }

--- a/src/cast-ui.js
+++ b/src/cast-ui.js
@@ -1,117 +1,25 @@
 // @flow
 /** @jsx h */
-import {cast, ui} from 'kaltura-player-js';
+import {cast} from 'kaltura-player-js';
+import * as presets from './ui-presets';
 
-// eslint-disable-next-line no-unused-vars
-const {style, Components, h} = ui;
 const {RemotePlayerUI} = cast;
 
 class CastUI extends RemotePlayerUI {
   playbackUI(props: Object): any {
-    return (
-      <div className={style.playbackGuiWrapper}>
-        <Components.KeyboardControl player={props.player} config={props.config} />
-        <Components.Loading player={props.player} />
-        <div className={style.playerGui} id="player-gui">
-          <Components.OverlayPortal />
-          <Components.BottomBar>
-            <Components.SeekBarPlaybackContainer showFramePreview showTimeBubble player={props.player} playerContainer={props.playerContainer} />
-            <div className={style.leftControls}>
-              <Components.PlaybackControls player={props.player} />
-              <Components.RewindControl player={props.player} step={10} />
-              <Components.ForwardControl player={props.player} step={10} />
-              <Components.TimeDisplayPlaybackContainer format="current / total" />
-            </div>
-            <div className={style.rightControls}>
-              <Components.VolumeControl player={props.player} />
-              <Components.LanguageControl player={props.player} />
-              <Components.CastControl player={props.player} />
-              <Components.FullscreenControl player={props.player} />
-            </div>
-          </Components.BottomBar>
-          <Components.CastOverlay player={props.player} />
-          <Components.OverlayAction player={props.player} />
-          <Components.PlaybackControls player={props.player} />
-        </div>
-        <Components.PrePlaybackPlayOverlay player={props.player} />
-        <Components.CastAfterPlay player={props.player} />
-      </div>
-    );
+    return presets.playbackUI(props);
   }
 
   liveUI(props: Object): any {
-    return (
-      <div className={style.playbackGuiWrapper}>
-        <Components.KeyboardControl player={props.player} config={props.config} />
-        <Components.Loading player={props.player} />
-        <div className={style.playerGui} id="player-gui">
-          <Components.OverlayPortal />
-          <Components.BottomBar>
-            <Components.SeekBarLivePlaybackContainer showFramePreview showTimeBubble player={props.player} playerContainer={props.playerContainer} />
-            <div className={style.leftControls}>
-              <Components.PlaybackControls player={props.player} />
-              <Components.LiveTag player={props.player} />
-            </div>
-            <div className={style.rightControls}>
-              <Components.VolumeControl player={props.player} />
-              <Components.LanguageControl player={props.player} />
-              <Components.CastControl player={props.player} />
-              <Components.FullscreenControl player={props.player} />
-            </div>
-          </Components.BottomBar>
-          <Components.CastOverlay player={props.player} />
-          <Components.OverlayAction player={props.player} />
-          <Components.PlaybackControls player={props.player} />
-        </div>
-        <Components.PrePlaybackPlayOverlay player={props.player} />
-        <Components.CastAfterPlay player={props.player} />
-      </div>
-    );
+    return presets.liveUI(props);
   }
 
-  idleUI(props: Object): any {
-    return (
-      <div className={style.playbackGuiWrapper}>
-        <Components.Loading player={props.player} />
-        <Components.CastOverlay player={props.player} />
-      </div>
-    );
+  idleUI(): any {
+    return presets.idleUI();
   }
 
   adsUI(props: Object): any {
-    return (
-      <div className={style.adGuiWrapper}>
-        <Components.KeyboardControl player={props.player} config={props.config} />
-        <Components.Loading player={props.player} />
-        <div className={style.playerGui} id="player-gui">
-          <Components.CastOverlay player={props.player} />
-          <Components.OverlayAction player={props.player} />
-          <div>
-            <Components.TopBar>
-              <div className={style.leftControls}>
-                <Components.AdNotice />
-              </div>
-              <div className={style.rightControls}>
-                <Components.AdLearnMore />
-              </div>
-            </Components.TopBar>
-            <Components.AdSkip player={props.player} />
-          </div>
-          <Components.BottomBar>
-            <div className={style.leftControls}>
-              <Components.PlaybackControls player={props.player} />
-              <Components.TimeDisplayAdsContainer />
-            </div>
-            <div className={style.rightControls}>
-              <Components.VolumeControl player={props.player} />
-              <Components.CastControl player={props.player} />
-              <Components.FullscreenControl player={props.player} />
-            </div>
-          </Components.BottomBar>
-          <Components.PlaybackControls player={props.player} />
-        </div>
-      </div>
-    );
+    return presets.adsUI(props);
   }
 }
 

--- a/src/ui-presets/ads.js
+++ b/src/ui-presets/ads.js
@@ -1,0 +1,76 @@
+//@flow
+/** @jsx h */
+import {ui} from 'kaltura-player-js';
+
+// eslint-disable-next-line no-unused-vars
+const {style, Components, h, preact} = ui;
+// eslint-disable-next-line no-unused-vars
+const {Fragment} = preact;
+const PRESET_NAME = 'Ads';
+
+/**
+ * Ads ui interface component
+ *
+ * @param {*} props component props
+ * @returns {?HTMLElement} player ui tree
+ */
+function AdsUI(props: any): ?React$Element<any> {
+  props.updateIsKeyboardEnabled(true);
+  return (
+    <div className={style.adGuiWrapper}>
+      <Components.Loading />
+      <div className={style.playerGui} id="player-gui">
+        <Components.GuiArea>
+          <Fragment>
+            <Components.CastOverlay />
+            <Components.OverlayAction />
+            <Components.PlaybackControls className={style.centerPlaybackControls} />
+            <Components.AdSkip />
+          </Fragment>
+          <Fragment>
+            <Components.TopBar
+              leftControls={
+                <Fragment>
+                  <Components.AdNotice />
+                </Fragment>
+              }
+              rightControls={
+                <Fragment>
+                  <Components.AdLearnMore />
+                </Fragment>
+              }
+            />
+            <Components.BottomBar
+              leftControls={
+                <Fragment>
+                  <Components.PlaybackControls />
+                  <Components.TimeDisplayAdsContainer />
+                </Fragment>
+              }
+              rightControls={
+                <Fragment>
+                  <Components.VolumeControl />
+                  <Components.CastControl />
+                  <Components.FullscreenControl />
+                </Fragment>
+              }
+            />
+          </Fragment>
+        </Components.GuiArea>
+      </div>
+    </div>
+  );
+}
+
+const AdsUIComponent = Components.withKeyboardEvent(PRESET_NAME)(AdsUI);
+AdsUIComponent.displayName = PRESET_NAME;
+/**
+ * Ads ui interface
+ *
+ * @export
+ * @param {*} props component props
+ * @returns {?HTMLElement} player ui tree
+ */
+export function adsUI(props: any): ?React$Element<any> {
+  return <AdsUIComponent {...props} />;
+}

--- a/src/ui-presets/idle.js
+++ b/src/ui-presets/idle.js
@@ -1,0 +1,35 @@
+//@flow
+/** @jsx h */
+import {ui} from 'kaltura-player-js';
+
+// eslint-disable-next-line no-unused-vars
+const {style, Components, h} = ui;
+// eslint-disable-next-line no-unused-vars
+const PRESET_NAME = 'Idle';
+
+/**
+ * Idle ui interface component
+ *
+ * @returns {React$Element} player ui tree
+ */
+function IdleUI(): React$Element<any> {
+  return (
+    <div className={style.playbackGuiWrapper}>
+      <Components.Loading />
+      <Components.CastOverlay />
+    </div>
+  );
+}
+
+IdleUI.displayName = PRESET_NAME;
+
+/**
+ * Idle ui interface
+ *
+ * @export
+ * @param {*} props component props
+ * @returns {React$Element} player ui tree
+ */
+export function idleUI(props: any): React$Element<any> {
+  return <IdleUI {...props} />;
+}

--- a/src/ui-presets/index.js
+++ b/src/ui-presets/index.js
@@ -1,0 +1,4 @@
+export {idleUI} from './idle';
+export {playbackUI} from './playback';
+export {adsUI} from './ads';
+export {liveUI} from './live';

--- a/src/ui-presets/live.js
+++ b/src/ui-presets/live.js
@@ -6,10 +6,10 @@ import {ui} from 'kaltura-player-js';
 const {style, Components, h, preact} = ui;
 // eslint-disable-next-line no-unused-vars
 const {Fragment, Component} = preact;
-
 const PRESET_NAME = 'Live';
+const withKeyboardEvent = ui.components.withKeyboardEvent;
 
-@Components.withKeyboardEvent(PRESET_NAME)
+@withKeyboardEvent(PRESET_NAME)
 class LiveUI extends Component {
   /**
    * @returns {void}

--- a/src/ui-presets/live.js
+++ b/src/ui-presets/live.js
@@ -1,0 +1,79 @@
+//@flow
+/** @jsx h */
+import {ui} from 'kaltura-player-js';
+
+// eslint-disable-next-line no-unused-vars
+const {style, Components, h, preact} = ui;
+// eslint-disable-next-line no-unused-vars
+const {Fragment, Component} = preact;
+
+const PRESET_NAME = 'Live';
+
+@Components.withKeyboardEvent(PRESET_NAME)
+class LiveUI extends Component {
+  /**
+   * @returns {void}
+   */
+  componentDidMount(): void {
+    const props = this.props;
+    props.updateIsKeyboardEnabled(true);
+  }
+
+  /**
+   * render component
+   *
+   * @returns {React$Element} - component element
+   * @memberof LiveUI
+   */
+  render() {
+    return (
+      <div className={style.playbackGuiWrapper}>
+        <Components.Loading />
+        <div className={style.playerGui} id="player-gui">
+          <Components.GuiArea>
+            <Fragment>
+              <Components.OverlayPortal />
+              <Components.CastOverlay />
+              <Components.OverlayAction />
+              <Components.PlaybackControls className={style.centerPlaybackControls} />
+            </Fragment>
+            <Fragment>
+              <Components.BottomBar
+                leftControls={
+                  <Fragment>
+                    <Components.PlaybackControls />
+                    <Components.LiveTag />
+                  </Fragment>
+                }
+                rightControls={
+                  <Fragment>
+                    <Components.VolumeControl />
+                    <Components.LanguageControl />
+                    <Components.CastControl />
+                    <Components.FullscreenControl />
+                  </Fragment>
+                }>
+                <Components.SeekBarLivePlaybackContainer showFramePreview showTimeBubble playerContainer={this.props.playerContainer} />
+              </Components.BottomBar>
+            </Fragment>
+          </Components.GuiArea>
+        </div>
+        <Components.PrePlaybackPlayOverlay />
+        <Components.CastAfterPlay />
+      </div>
+    );
+  }
+}
+
+LiveUI.displayName = PRESET_NAME;
+
+/**
+ * Live ui interface
+ *
+ * @export
+ * @param {*} props component props
+ * @returns {React$Element<any>} player ui tree
+ */
+export function liveUI(props: any): React$Element<any> {
+  return <LiveUI {...props} />;
+}

--- a/src/ui-presets/playback.js
+++ b/src/ui-presets/playback.js
@@ -7,8 +7,9 @@ const {style, Components, h, preact} = ui;
 // eslint-disable-next-line no-unused-vars
 const {Fragment, Component} = preact;
 const PRESET_NAME = 'Playback';
+const withKeyboardEvent = ui.components.withKeyboardEvent;
 
-@Components.withKeyboardEvent(PRESET_NAME)
+@withKeyboardEvent(PRESET_NAME)
 class PlaybackUI extends Component {
   /**
    * @returns {void}

--- a/src/ui-presets/playback.js
+++ b/src/ui-presets/playback.js
@@ -1,0 +1,80 @@
+//@flow
+/** @jsx h */
+import {ui} from 'kaltura-player-js';
+
+// eslint-disable-next-line no-unused-vars
+const {style, Components, h, preact} = ui;
+// eslint-disable-next-line no-unused-vars
+const {Fragment, Component} = preact;
+const PRESET_NAME = 'Playback';
+
+@Components.withKeyboardEvent(PRESET_NAME)
+class PlaybackUI extends Component {
+  /**
+   * @returns {void}
+   */
+  componentDidMount(): void {
+    const props = this.props;
+    props.updateIsKeyboardEnabled(true);
+  }
+
+  /**
+   * render component
+   *
+   * @returns {React$Element} - component element
+   * @memberof PlaybackUI
+   */
+  render() {
+    return (
+      <div className={style.playbackGuiWrapper}>
+        <Components.Loading />
+        <div className={style.playerGui} id="player-gui">
+          <Components.GuiArea>
+            <Fragment>
+              <Components.OverlayPortal />
+              <Components.CastOverlay />
+              <Components.OverlayAction />
+              <Components.PlaybackControls className={style.centerPlaybackControls} />
+            </Fragment>
+            <Fragment>
+              <Components.BottomBar
+                leftControls={
+                  <Fragment>
+                    <Components.PlaybackControls />
+                    <Components.RewindControl step={10} />
+                    <Components.ForwardControl step={10} />
+                    <Components.TimeDisplayPlaybackContainer format="current / total" />
+                  </Fragment>
+                }
+                rightControls={
+                  <Fragment>
+                    <Components.VolumeControl />
+                    <Components.LanguageControl />
+                    <Components.CastControl />
+                    <Components.FullscreenControl />
+                  </Fragment>
+                }>
+                <Components.SeekBarPlaybackContainer showFramePreview showTimeBubble playerContainer={this.props.playerContainer} />
+              </Components.BottomBar>
+            </Fragment>
+          </Components.GuiArea>
+        </div>
+        <Components.PrePlaybackPlayOverlay />
+        <Components.CastAfterPlay />
+      </div>
+    );
+  }
+}
+
+PlaybackUI.displayName = PRESET_NAME;
+
+/**
+ * Playback ui interface
+ *
+ * @export
+ * @param {*} props component props
+ * @returns {React$Element} player ui tree
+ */
+export function playbackUI(props: any): React$Element<any> {
+  return <PlaybackUI {...props} />;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,15 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.5.tgz#a2c50de5c8b6d708ab95be5e6053936c1884a4de"
+  integrity sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==
+  dependencies:
+    "@babel/types" "^7.12.5"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz#5bf0d495a3f757ac3bda48b5bf3b3ba309c72ba3"
@@ -118,6 +127,17 @@
     "@babel/helper-optimise-call-expression" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-replace-supers" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.10.4"
+
+"@babel/helper-create-class-features-plugin@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz#3c45998f431edd4a9214c5f1d3ad1448a6137f6e"
+  integrity sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==
+  dependencies:
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-member-expression-to-functions" "^7.12.1"
+    "@babel/helper-optimise-call-expression" "^7.10.4"
+    "@babel/helper-replace-supers" "^7.12.1"
     "@babel/helper-split-export-declaration" "^7.10.4"
 
 "@babel/helper-create-regexp-features-plugin@^7.10.4":
@@ -175,6 +195,13 @@
   integrity sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==
   dependencies:
     "@babel/types" "^7.10.5"
+
+"@babel/helper-member-expression-to-functions@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz#fba0f2fcff3fba00e6ecb664bb5e6e26e2d6165c"
+  integrity sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==
+  dependencies:
+    "@babel/types" "^7.12.1"
 
 "@babel/helper-module-imports@^7.10.4":
   version "7.10.4"
@@ -236,6 +263,16 @@
     "@babel/traverse" "^7.10.4"
     "@babel/types" "^7.10.4"
 
+"@babel/helper-replace-supers@^7.12.1":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz#f009a17543bbbbce16b06206ae73b63d3fca68d9"
+  integrity sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.12.1"
+    "@babel/helper-optimise-call-expression" "^7.10.4"
+    "@babel/traverse" "^7.12.5"
+    "@babel/types" "^7.12.5"
+
 "@babel/helper-simple-access@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz#0f5ccda2945277a2a7a2d3a821e15395edcf3461"
@@ -250,6 +287,13 @@
   integrity sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==
   dependencies:
     "@babel/types" "^7.10.4"
+
+"@babel/helper-split-export-declaration@^7.11.0":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz#f8a491244acf6a676158ac42072911ba83ad099f"
+  integrity sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==
+  dependencies:
+    "@babel/types" "^7.11.0"
 
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
@@ -289,6 +333,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.5.tgz#e7c6bf5a7deff957cec9f04b551e2762909d826b"
   integrity sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==
 
+"@babel/parser@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
+  integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
+
 "@babel/plugin-proposal-async-generator-functions@^7.10.4":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz#3491cabf2f7c179ab820606cec27fed15e0e8558"
@@ -305,6 +354,15 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-proposal-decorators@^7.10.5":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.12.1.tgz#59271439fed4145456c41067450543aee332d15f"
+  integrity sha512-knNIuusychgYN8fGJHONL0RbFxLGawhXOJNLBk75TniTsZZeA+wdkDuv6wp4lGwzQEKjZi6/WYtnb3udNPmQmQ==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.12.1"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-decorators" "^7.12.1"
 
 "@babel/plugin-proposal-dynamic-import@^7.10.4":
   version "7.10.4"
@@ -390,6 +448,13 @@
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz#6644e6a0baa55a61f9e3231f6c9eeb6ee46c124c"
   integrity sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-decorators@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.12.1.tgz#81a8b535b284476c41be6de06853a8802b98c5dd"
+  integrity sha512-ir9YW5daRrTYiy9UJ2TzdNIJEZu8KclVzDcfSt4iEmOtwQ4llPtWInNKJyKnVXp1vE4bbVd5S31M/im3mYMO1w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -870,10 +935,34 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
+"@babel/traverse@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.5.tgz#78a0c68c8e8a35e4cacfd31db8bb303d5606f095"
+  integrity sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.5"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.12.5"
+    "@babel/types" "^7.12.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
 "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.5.tgz#d88ae7e2fde86bfbfe851d4d81afa70a997b5d15"
   integrity sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.11.0", "@babel/types@^7.12.1", "@babel/types@^7.12.5":
+  version "7.12.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.6.tgz#ae0e55ef1cce1fbc881cd26f8234eb3e657edc96"
+  integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"


### PR DESCRIPTION
### Description of the Changes

Issue:
1. GuiArea split to two container one contain the bottom/top bars and interactive and second the rest.
2. preset active in UI use displayName for preset changes, the name was missing so no preset change at all.

Solution:
1. add names for preset for active-preset to be able to replace presets.
2. split guiArea into 2 containers as expected on UI.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
