### PR TITLE
feat(FEC-10686): move startTime config from playback to sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "webpack --mode production",
     "clean": "rm -rf ./dist",
     "commit:dist": "git add --force --all dist && (git commit -m 'chore: update dist' || exit 0)",
-    "dev": "webpack-dev-server --https --mode development",
+    "dev": "webpack-dev-server --mode development",
     "docs:generate": "documentation build flow-typed/** src/** -f md -o docs/api.md",
     "docs:serve": "documentation serve flow-typed/** src/** --watch",
     "eslint": "eslint . --color",

--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -794,7 +794,7 @@ class CastPlayer extends BaseRemotePlayer {
     this._triggerInitialPlayerEvents();
     this._tracksManager.parseTracks();
     this._handleFirstPlay();
-    let startTime = this._playerConfig.playback.startTime;
+    let startTime = this._playerConfig.sources.startTime;
     if (this.isLive() && (startTime === -1 || (typeof this.duration === 'number' && startTime >= this.duration - LIVE_EDGE_THRESHOLD))) {
       this._isOnLiveEdge = true;
     }
@@ -846,7 +846,7 @@ class CastPlayer extends BaseRemotePlayer {
   _getLoadOptions(snapshot: PlayerSnapshot): Object {
     const loadOptions = {
       autoplay: this._playerConfig.playback.autoplay,
-      currentTime: this._playerConfig.playback.startTime,
+      currentTime: this._playerConfig.sources.startTime,
       media: {}
     };
     if (this.textStyle && !this.textStyle.isEqual(snapshot.textStyle)) {


### PR DESCRIPTION
### Description of the Changes

move startTime to the sources config so it will take place only on the a specific source.



### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
