### PR TITLE
fix(FEC-11073): chromecast casting doesn't work on Player V7 when content is protected with KS

### DIFF
--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -116,6 +116,9 @@ class CastPlayer extends BaseRemotePlayer {
    */
   loadMedia(mediaInfo: Object, options?: Object): Promise<*> {
     CastPlayer._logger.debug('Load media', mediaInfo, options);
+    if (this._playerConfig.session && this._playerConfig.session.ks && !mediaInfo.ks) {
+      mediaInfo.ks = this._playerConfig.session.ks;
+    }
     this._mediaInfo = mediaInfo;
     return this._castMedia({mediaInfo}, options);
   }

--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -116,8 +116,9 @@ class CastPlayer extends BaseRemotePlayer {
    */
   loadMedia(mediaInfo: Object, options?: Object): Promise<*> {
     CastPlayer._logger.debug('Load media', mediaInfo, options);
-    if (this._playerConfig.session && this._playerConfig.session.ks && !mediaInfo.ks) {
-      mediaInfo.ks = this._playerConfig.session.ks;
+    const ks = Utils.Object.getPropertyPath(this._playerConfig, 'session.ks');
+    if (!mediaInfo.ks && ks) {
+      mediaInfo.ks = ks;
     }
     this._mediaInfo = mediaInfo;
     return this._castMedia({mediaInfo}, options);


### PR DESCRIPTION
### Description of the Changes

Making sure KS is passed to receiver by adding KS to mediaInfo object, as part of loadMedia function.

Solves [FEC-11073](https://kaltura.atlassian.net/browse/FEC-11073)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
