### PR TITLE
fix(FEC-11144): Casting doesn't work if you stop it and re-initiate

### DIFF
--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -237,7 +237,7 @@ class CastPlayer extends BaseRemotePlayer {
   destroy(): void {
     this._castRemotePlayerController.removeEventListener(cast.framework.RemotePlayerEventType.IS_CONNECTED_CHANGED, this._isConnectedHandler);
     this._castContext.removeEventListener(cast.framework.CastContextEventType.SESSION_STATE_CHANGED, this._sessionStateChangedHandler);
-    this._destroy();
+    this._cleanSessionData();
   }
 
   /**
@@ -697,7 +697,7 @@ class CastPlayer extends BaseRemotePlayer {
     const snapshot = new PlayerSnapshot(this);
     const payload = new RemoteDisconnectedPayload(this, snapshot);
     this.pause();
-    this._destroy();
+    this._cleanSessionData();
     this._remoteControl.onRemoteDeviceDisconnected(payload);
   }
 
@@ -944,7 +944,7 @@ class CastPlayer extends BaseRemotePlayer {
     }
   };
 
-  _destroy(): void {
+  _cleanSessionData(): void {
     clearInterval(this._mediaInfoIntervalId);
     if (this._destroyed) return;
     this._destroyed = true;

--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -224,7 +224,7 @@ class CastPlayer extends BaseRemotePlayer {
     this._engine.reset();
     this._adsManager.reset();
     this._stateManager.reset();
-    this._readyPromise = this._createReadyPromise();
+    this._createReadyPromise();
     this.dispatchEvent(new FakeEvent(EventType.PLAYER_RESET));
   }
 
@@ -238,18 +238,7 @@ class CastPlayer extends BaseRemotePlayer {
     clearInterval(this._mediaInfoIntervalId);
     this._castRemotePlayerController.removeEventListener(cast.framework.RemotePlayerEventType.IS_CONNECTED_CHANGED, this._isConnectedHandler);
     this._castContext.removeEventListener(cast.framework.CastContextEventType.SESSION_STATE_CHANGED, this._sessionStateChangedHandler);
-    if (this._destroyed) return;
-    this._destroyed = true;
-    this._firstPlay = true;
-    this._ended = false;
-    this._isOnLiveEdge = false;
-    this._readyPromise = null;
-    this._eventManager.destroy();
-    this._tracksManager.destroy();
-    this._engine.destroy();
-    this._adsManager.destroy();
-    this._stateManager.destroy();
-    this.dispatchEvent(new FakeEvent(EventType.PLAYER_DESTROY));
+    this._destroy();
   }
 
   /**
@@ -709,7 +698,7 @@ class CastPlayer extends BaseRemotePlayer {
     const snapshot = new PlayerSnapshot(this);
     const payload = new RemoteDisconnectedPayload(this, snapshot);
     this.pause();
-    this.destroy();
+    this._destroy();
     this._remoteControl.onRemoteDeviceDisconnected(payload);
   }
 
@@ -786,7 +775,7 @@ class CastPlayer extends BaseRemotePlayer {
   }
 
   _resumeSession(): void {
-    this._readyPromise = this._createReadyPromise();
+    this._createReadyPromise();
     this._mediaInfoIntervalId = setInterval(() => {
       const mediaSession = this._castSession.getMediaSession();
       if (mediaSession && mediaSession.customData) {
@@ -955,6 +944,21 @@ class CastPlayer extends BaseRemotePlayer {
       this._setupLocalPlayer();
     }
   };
+
+  _destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this._firstPlay = true;
+    this._ended = false;
+    this._isOnLiveEdge = false;
+    this._readyPromise = null;
+    this._eventManager.destroy();
+    this._tracksManager.destroy();
+    this._engine.destroy();
+    this._adsManager.destroy();
+    this._stateManager.destroy();
+    this.dispatchEvent(new FakeEvent(EventType.PLAYER_DESTROY));
+  }
 }
 
 export {CastPlayer};

--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -235,7 +235,6 @@ class CastPlayer extends BaseRemotePlayer {
    * @memberof CastPlayer
    */
   destroy(): void {
-    clearInterval(this._mediaInfoIntervalId);
     this._castRemotePlayerController.removeEventListener(cast.framework.RemotePlayerEventType.IS_CONNECTED_CHANGED, this._isConnectedHandler);
     this._castContext.removeEventListener(cast.framework.CastContextEventType.SESSION_STATE_CHANGED, this._sessionStateChangedHandler);
     this._destroy();
@@ -946,6 +945,7 @@ class CastPlayer extends BaseRemotePlayer {
   };
 
   _destroy(): void {
+    clearInterval(this._mediaInfoIntervalId);
     if (this._destroyed) return;
     this._destroyed = true;
     this._firstPlay = true;


### PR DESCRIPTION
### Description of the Changes

Happens since `IS_CONNECTED` listener removed on destroy of the first session, so no listener is existing to initiate the next session.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
