### PR TITLE
fix(FEC-11156): cast button appears for one player only when multiple players configured on the page and casting failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ dist: xenial
 language: node_js
 node_js:
   - 'node'
-
+env:
+  global:
+    - NODE_OPTIONS="--openssl-legacy-provider"
 addons:
   chrome: stable
 

--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -60,7 +60,7 @@ class CastPlayer extends BaseRemotePlayer {
   };
 
   static _isAvailable: boolean = false;
-  static _loadPromise: any = null;
+  static _loadPromise: ?Promise<void> = null;
 
   _remoteSession: RemoteSession;
   _castSession: Object;
@@ -654,6 +654,8 @@ class CastPlayer extends BaseRemotePlayer {
     const mediaSession = this._castSession.getMediaSession();
     const localEntryId = snapshot.config.sources.id;
     const savedEntryId = Utils.Object.getPropertyPath(mediaSession, 'customData.mediaInfo.entryId');
+
+    // savedEntryId === localEntryId if a player has started casting and the page was refreshed
     if (!(this.isCastInitiator() || (savedEntryId && savedEntryId === localEntryId))) {
       return;
     }


### PR DESCRIPTION
### Description of the Changes

Prevent calling CastLoader.load when multiple players are loaded one after the other
Distinguish between a casting and a non-casting player
Fixes FEC-11156

Related PRs:
https://github.com/kaltura/kaltura-player-js/pull/495
https://github.com/kaltura/playkit-js-ui/pull/640

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
