### PR TITLE
fix(FEC-11708): V3 - cast on multiple players - if try to cast when other player are casting, the player will be disabled

### DIFF
--- a/src/cast-player.js
+++ b/src/cast-player.js
@@ -960,9 +960,9 @@ class CastPlayer extends BaseRemotePlayer {
       }
     } else {
       // savedEntryId === localEntryId if this player's cast session was stopped by the user
+      this._isCastInitiator = false;
       const savedEntryId = this._getSessionEntryId(this._castSession);
       if (savedEntryId && savedEntryId === localEntryId) {
-        this._isCastInitiator = false;
         this._setupLocalPlayer();
       }
     }


### PR DESCRIPTION
### Description of the Changes

We set isCastInitiator=true on cast button click, and set it to false if the cast request didn't succeed or the cast menu lost focus.

However, if player A is already casting, when we click on the button in player B, we set isCastInitiator=true but we have no event to indicate that the cast request did not succeed, since a cast request can't be made at all while player A is casting, and so for player B isCastinitiator is not set to false.

When having 3+ players this can cause a situation where multiple players will have isCastInitiator set to true when a player starts casting, which will cause them all to connect to the same remote session.

To prevent this, we need to reset isCastInitiator for ALL players on disconnect.

Fixes FEC-11708.
Related PR: https://github.com/kaltura/playkit-js-ui/pull/643/commits/0470ffa8bc756a34ab214168d6f522e9ea917705

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
